### PR TITLE
Use full user path instead of ~

### DIFF
--- a/stock_and_flow/02_prep_delivery_dist_data.r
+++ b/stock_and_flow/02_prep_delivery_dist_data.r
@@ -13,7 +13,7 @@ library(ggplot2)
 library(data.table)
 
 rm(list=ls())
-code_dir <- "~/repos/map-itn-cube/stock_and_flow"
+code_dir <- "/Users/bertozzivill/repos/map-itn-cube/stock_and_flow"
 sf_countries <- fread(file.path(code_dir, "for_gcloud", "batch_country_list.tsv"))
 names(sf_countries) <- "ISO3"
 


### PR DESCRIPTION
Step 1a-1d refer to the directory containing code as `/Users/bertozzivill/repos/map-itn-cube/stock_and_flow`, while this one uses `~`. The consistency makes it easier to run the model in docker.

If you prefer, I could instead change step 1a-1d to use `~/repos/...`

This is just an intermediate step, at a later stage I'd like to add the option to pass in paths to step 1 and 2 (similar to step 3+).