### PR TITLE
Refactor out in-/output paths and create cli

### DIFF
--- a/stock_and_flow/05_aggregate_for_cube.r
+++ b/stock_and_flow/05_aggregate_for_cube.r
@@ -9,7 +9,7 @@
 ##############################################################################################################
 
 
-aggregate_indicators <- function(reference_dir, list_out_dir){
+aggregate_indicators <- function(reference_dir, access_draws_templ_csvs, metrics_for_cube_csv, means_for_cube_csv, national_access_csv) {
   
   ### Prep  #####----------------------------------------------------------------------------------------------------------------------------------
   
@@ -20,8 +20,8 @@ aggregate_indicators <- function(reference_dir, list_out_dir){
   ### Country Loop  #####----------------------------------------------------------------------------------------------------------------------------------
   print("Collecting access and percapita nets for all countries")
   print(countries)
-  
-  access_fnames <- file.path(reference_dir, paste0(countries, "_access_draws.csv"))
+
+  access_fnames <- lapply(countries, function(x) str_interp(access_draws_templ_csvs, list(country=x)))
   metrics_for_cube <- lapply(access_fnames, fread)
   metrics_for_cube <- rbindlist(metrics_for_cube)
   
@@ -33,10 +33,11 @@ aggregate_indicators <- function(reference_dir, list_out_dir){
   national_access <- metrics_for_cube[, list(nat_access=mean(nat_access),
                                              nat_percapita_nets=mean(stockflow_percapita_nets)),
                                   by=list(iso3, year, month, time)]
-  
-  cube_out_dir <- file.path(list_out_dir, "for_cube")
-  dir.create(cube_out_dir, recursive = T, showWarnings = F)
-  
+
+  for (dir in unique(dirname(c(metrics_for_cube_csv, means_for_cube_csv, national_access_csv)))) {
+    dir.create(dir, recursive = T, showWarnings = F)
+  }
+
   # keep only 100 draws for cube uncertainty propagation, also can drop hhsize as it's constant across percaptia nets and access
   samples <- sample(unique(metrics_for_cube$ITER), 500)
   metrics_for_cube <- metrics_for_cube[ITER %in% samples & hh_size==1, list(ITER, iso3, year, month, time, nat_access, nat_percapita_nets=stockflow_percapita_nets)]
@@ -44,13 +45,11 @@ aggregate_indicators <- function(reference_dir, list_out_dir){
                                                          sample=1:length(samples)), all=T)
   metrics_for_cube <- metrics_for_cube[order(sample)]
 
-  write.csv(metrics_for_cube, file=file.path(cube_out_dir, "stock_and_flow_by_draw.csv"), row.names=F)
-  write.csv(means_for_cube, file=file.path(cube_out_dir, "stock_and_flow_probs_means.csv"), row.names=F)
-  write.csv(national_access, file=file.path(cube_out_dir, "stock_and_flow_access_npc.csv"), row.names=F)
+  write.csv(metrics_for_cube, file=metrics_for_cube_csv, row.names=F)
+  write.csv(means_for_cube, file=means_for_cube_csv, row.names=F)
+  write.csv(national_access, file=national_access_csv, row.names=F)
+}
 
-} 
-
-# dsub --provider google-v2 --project map-special-0001 --boot-disk-size 50 --image eu.gcr.io/map-special-0001/map-geospatial-jags --preemptible --retries 1 --wait --regions europe-west1 --label "type=itn_stockflow" --machine-type n1-standard-4 --logging gs://map_users/amelia/itn/stock_and_flow/logs --input-recursive reference_dir=gs://map_users/amelia/itn/stock_and_flow/results/20200930_new_2020_dists CODE=gs://map_users/amelia/itn/code/stock_and_flow/ --output-recursive list_out_dir=gs://map_users/amelia/itn/stock_and_flow/results/20200930_new_2020_dists --command 'cd ${CODE}; Rscript 05_aggregate_for_cube.r'
 package_load <- function(package_list){
   # package installation/loading
   new_packages <- package_list[!(package_list %in% installed.packages()[,"Package"])]
@@ -58,19 +57,29 @@ package_load <- function(package_list){
   lapply(package_list, library, character.only=T)
 }
 
-package_load(c("data.table","rjags", "zoo", "ggplot2", "gridExtra"))
-theme_set(theme_minimal(base_size = 12))
+main <- function() {
+  package_load(c("data.table","rjags", "zoo", "ggplot2", "gridExtra", "argparser", "stringr"))
+  theme_set(theme_minimal(base_size = 12))
 
-if(Sys.getenv("reference_dir")=="") {
-  reference_dir <- "/Volumes/GoogleDrive/My Drive/stock_and_flow/results/20200418_BMGF_ITN_C1.00_R1.00_V2"
-  list_out_dir <- reference_dir
-} else {
-  reference_dir <- Sys.getenv("reference_dir") 
-  list_out_dir <- Sys.getenv("list_out_dir")
+  if(Sys.getenv("reference_dir")=="") {
+    reference_dir <- "/Volumes/GoogleDrive/My Drive/stock_and_flow/results/20200418_BMGF_ITN_C1.00_R1.00_V2"
+    list_out_dir <- reference_dir
+  } else {
+    reference_dir <- Sys.getenv("reference_dir")
+    list_out_dir <- Sys.getenv("list_out_dir")
+  }
+
+  parser <- arg_parser("Collect national-level outputs to pass along to the itn_cube code.")
+  parser <- add_argument(parser, "--reference_dir", help="Location where stock and flow results are saved. Default dir can also be set with env 'reference_dir'", default=reference_dir) #  Not called "main dir" to avoid being overwritten when stock and flow results are loaded.
+  parser <- add_argument(parser, "--access_draws", help="Input CSV files. Posterior draws of ITN access. Templated with variable 'country'. Default dir can also be set with env 'reference_dir'", default=file.path(reference_dir, "${country}_access_draws.csv"))
+  parser <- add_argument(parser, "--metrics_for_cube", help="Output CSV file. Draw-level access metrics (NPC, probability of not having a net, and nets per household) for cube. Default path can be adjusted with env 'list_out_dir'", default=file.path(list_out_dir, "for_cube", "stock_and_flow_by_draw.csv"))
+  parser <- add_argument(parser, "--means_for_cube", help="Output CSV file. Mean access metrics (NPC, probability of not having a net, and nets per household) for cube. Default path can be adjusted with env 'list_out_dir'", default=file.path(list_out_dir, "for_cube", "stock_and_flow_probs_means.csv"))
+  parser <- add_argument(parser, "--national_access", help="Output CSV file. Mean national access and NPC for cube. Default path can be adjusted with env 'list_out_dir'", default=file.path(list_out_dir, "for_cube", "stock_and_flow_access_npc.csv"))
+  argv <- parse_args(parser)
+
+  aggregate_indicators(argv$reference_dir, argv$access_draws, argv$metrics_for_cube, argv$means_for_cube, argv$national_access)
 }
 
+# dsub --provider google-v2 --project map-special-0001 --boot-disk-size 50 --image eu.gcr.io/map-special-0001/map-geospatial-jags --preemptible --retries 1 --wait --regions europe-west1 --label "type=itn_stockflow" --machine-type n1-standard-4 --logging gs://map_users/amelia/itn/stock_and_flow/logs --input-recursive reference_dir=gs://map_users/amelia/itn/stock_and_flow/results/20200930_new_2020_dists CODE=gs://map_users/amelia/itn/code/stock_and_flow/ --output-recursive list_out_dir=gs://map_users/amelia/itn/stock_and_flow/results/20200930_new_2020_dists --command 'cd ${CODE}; Rscript 05_aggregate_for_cube.r'
 
-aggregate_indicators(reference_dir, list_out_dir)
-
-
-
+main()


### PR DESCRIPTION
The advantages of these changes are that:
- Flexibility to read/write every in/output from anywhere. Groups of in/outputs are decoupled.
- The code is more self-explanatory/self-documenting
- The CLI describes exactly what goes in and comes out. Documentation of all those dependencies are in one spot.

The following changes were made in scripts 3, 5, and 6
- Removed hardcoded paths
- Created a command line interface (with argparser) containing an argument for every in- and output file
- Documented those in- and outputs based on the description in the Readme file
- Removed dependency on where (which directory) the script was run from

The changes retain backwards compatibility in that the same default values are still used when running the scripts without arguments. The in- and output directories can also still be manipulated using the previously used environment variables.

The only place where I had to break this was in script 3, where `country`, `sensitivity_type` and `sensitivity_survey_count` are now named arguments instead of postional ones. So instead of `Rscript 03_stock_and_flow.r ERI`, you must use `Rscript 03_stock_and_flow.r --country ERI`. Similarly, `--sensitivity_type` and `--sensitivity_survey_count` are used for the other two.

Let me know if you have any concerns. If not, I'll make similar changes to the ITN cube scripts that are run on GCP.
