### PR TITLE
Refactor out in-/output paths and create cli part 2

### DIFF
--- a/itn_cube/000_extract_covariates.r
+++ b/itn_cube/000_extract_covariates.r
@@ -9,30 +9,12 @@
 ## NB: This script requires an immense amount of memory, only rerun it if you absolutely must.
 ##############################################################################################################
 
-# DON'T USE THIS-- FOR FULL DSUB SEE 000_MAKE_DSUB.R
-# dsub --provider google-v2 --project map-special-0001 --image gcr.io/map-demo-0001/map_geospatial --regions europe-west1 --label "type=itn_cube" --machine-type n1-ultramem-40 --logging gs://map_users/amelia/itn/itn_cube/logs --input-recursive input_dir=gs://map_users/amelia/itn/itn_cube/input_data main_indir=gs://map_users/amelia/itn/itn_cube/results/covariates/20190729/ cov_dir=gs://mastergrids_5km --input run_individually=gs://map_users/amelia/itn/code/generate_cube/run_individually.txt CODE=gs://map_users/amelia/itn/code/generate_cube/03_prep_covariates.r --output-recursive main_outdir=gs://map_users/amelia/itn/itn_cube/results/covariates/20190729/ --command 'Rscript ${CODE}'
-
-
 package_load <- function(package_list){
   # package installation/loading
   new_packages <- package_list[!(package_list %in% installed.packages()[,"Package"])]
   if(length(new_packages)) install.packages(new_packages)
   lapply(package_list, library, character.only=T)
 }
-
-package_load(c("zoo","raster", "doParallel", "data.table", "rgdal", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm"))
-
-if(Sys.getenv("input_dir")=="") {
-  input_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/input_data/"
-  main_indir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20190614_rearrange_scripts/"
-  main_outdir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20190614_rearrange_scripts/"
-} else {
-  input_dir <- Sys.getenv("input_dir")
-  main_indir <- Sys.getenv("main_indir")
-  main_outdir <- Sys.getenv("main_outdir")
-}
-
-prediction_years <- 2000:2021
 
 # Functions ------------------------------------------------------------
 
@@ -63,129 +45,152 @@ extract_values <- function(raster_fname_list, extraction_indices, reference_rast
   return(extracted_covs)
 }
 
-# Load list of covariates  ------------------------------------------------------------
+extract_covariates <- function(input_dir, main_indir, main_outdir, prediction_years) {
+  # Load list of covariates  ------------------------------------------------------------
 
-# load covariates
-cov_dt <- fread(file.path(main_indir, "covariate_key.csv"))
-cov_dt[, used_sam:= as.logical(used_sam)]
+  # load covariates
+  cov_dt <- fread(file.path(main_indir, "covariate_key.csv"))
+  cov_dt[, used_sam:= as.logical(used_sam)]
 
-# todo: remove this column when switching to new covariates
-cov_dt <- cov_dt[used_sam==T]
+  # todo: remove this column when switching to new covariates
+  cov_dt <- cov_dt[used_sam==T]
 
-# attach on list of vm directories passed into script via dsub
-vm_dirs <- data.table(cov_name=names(Sys.getenv(cov_dt$cov_name)), vm_path=Sys.getenv(cov_dt$cov_name))
-cov_dt <- merge(cov_dt, vm_dirs, by="cov_name", all.x=T)
+  # attach on list of vm directories passed into script via dsub
+  vm_dirs <- data.table(cov_name=names(Sys.getenv(cov_dt$cov_name)), vm_path=Sys.getenv(cov_dt$cov_name))
+  cov_dt <- merge(cov_dt, vm_dirs, by="cov_name", all.x=T)
 
-write.csv(cov_dt, file.path(main_outdir, "covariate_key.csv"), row.names=F)
+  write.csv(cov_dt, file.path(main_outdir, "covariate_key.csv"), row.names=F)
 
-# find the "valid" cell values for which we want to predict in the itn prediction step
-reference_raster <- raster(file.path(input_dir, "general/african_cn5km_2013_no_disputes.tif"))
-raster_indices <- which_non_null(reference_raster)
+  # find the "valid" cell values for which we want to predict in the itn prediction step
+  reference_raster <- raster(file.path(input_dir, "general/african_cn5km_2013_no_disputes.tif"))
+  raster_indices <- which_non_null(reference_raster)
 
-### Static covariates  ----------------------------------------------------------------------------#######################  
+  ### Static covariates  ----------------------------------------------------------------------------#######################
 
-print("Extracting static covariates")
-static_cov_dt <- cov_dt[type=="static", list(fname=file.path(vm_path, fname))]
+  print("Extracting static covariates")
+  static_cov_dt <- cov_dt[type=="static", list(fname=file.path(vm_path, fname))]
 
-all_static <- extract_values(static_cov_dt$fname, raster_indices, reference_raster)
-write.csv(all_static, file.path(main_outdir, "static_covariates.csv"), row.names = F)
+  all_static <- extract_values(static_cov_dt$fname, raster_indices, reference_raster)
+  write.csv(all_static, file.path(main_outdir, "static_covariates.csv"), row.names = F)
 
-rm(all_static); gc()
-print("static covariates successfully extracted")
+  rm(all_static); gc()
+  print("static covariates successfully extracted")
 
-### Annual covariates  ----------------------------------------------------------------------------#######################  
+  ### Annual covariates  ----------------------------------------------------------------------------#######################
 
-print("Extracting annual covariates")
-annual_cov_dt <- cov_dt[type=="year"]
+  print("Extracting annual covariates")
+  annual_cov_dt <- cov_dt[type=="year"]
 
-print("Extracting whole-continent values")
-ncores <- detectCores()
-print(paste("--> Machine has", ncores, "cores available"))
-registerDoParallel(ncores-2)
+  print("Extracting whole-continent values")
+  ncores <- detectCores()
+  print(paste("--> Machine has", ncores, "cores available"))
+  registerDoParallel(ncores-2)
 
-all_annual <- foreach(this_year=prediction_years) %dopar%{
-  
-  print(this_year)
-  
-  these_fnames <- copy(annual_cov_dt)
-  these_fnames[, year_to_use:=pmin(end_year, this_year)] # cap year by covariate availability
-  these_fnames[, year_to_use:=pmax(year_to_use, start_year)] 
-  
-  # if (this_year%%5>0){
-  #   these_fnames[fpath %like% "Population", fname:=gsub("YEAR", "YEAR-Interp", fname)]
-  # }
-  
-  these_fnames[, new_fname:=str_replace(fname, "YEAR", as.character(year_to_use))]
-  these_fnames[, full_fname:= file.path(vm_path, new_fname)]
-  
-  subset <- extract_values(these_fnames$full_fname, raster_indices, reference_raster, names=these_fnames$cov_name)
-  subset[, year:=this_year]
-  setcolorder(subset, c("year", "cellnumber", these_fnames$cov_name))
-  
-  return(subset)
+  all_annual <- foreach(this_year=prediction_years) %dopar%{
+
+    print(this_year)
+
+    these_fnames <- copy(annual_cov_dt)
+    these_fnames[, year_to_use:=pmin(end_year, this_year)] # cap year by covariate availability
+    these_fnames[, year_to_use:=pmax(year_to_use, start_year)]
+
+    # if (this_year%%5>0){
+    #   these_fnames[fpath %like% "Population", fname:=gsub("YEAR", "YEAR-Interp", fname)]
+    # }
+
+    these_fnames[, new_fname:=str_replace(fname, "YEAR", as.character(year_to_use))]
+    these_fnames[, full_fname:= file.path(vm_path, new_fname)]
+
+    subset <- extract_values(these_fnames$full_fname, raster_indices, reference_raster, names=these_fnames$cov_name)
+    subset[, year:=this_year]
+    setcolorder(subset, c("year", "cellnumber", these_fnames$cov_name))
+
+    return(subset)
+  }
+
+  all_annual <- rbindlist(all_annual)
+
+  landcov_names <- names(all_annual)[names(all_annual) %like% "Landcover"]
+  for (this_name in landcov_names){
+    all_annual[[this_name]] <- all_annual[[this_name]]/100
+  }
+
+  write.csv(all_annual, file.path(main_outdir, "annual_covariates.csv"), row.names = F)
+
+  rm(all_annual); gc()
+  print("annual covariates successfully extracted")
+
+  ### Fully dynamic covariates: extract and apply by month and year  ----------------------------------------------------------------------------#######################
+
+  print("Extracting dynamic covariates")
+
+  dynamic_cov_dt <- cov_dt[type=="yearmon"]
+  all_yearmons <- data.table(expand.grid(1:12, prediction_years))
+  names(all_yearmons) <- c("month", "year")
+
+  registerDoParallel(ncores-2)
+
+  dynamic_outdir <- file.path(main_outdir, "dynamic_covariates")
+  if (!dir.exists(dynamic_outdir)){
+    dir.create(dynamic_outdir)
+  }
+
+  all_dynamic <- foreach(month_index=1:nrow(all_yearmons)) %dopar% {
+
+    print(all_yearmons[month_index])
+
+    this_month <- all_yearmons[month_index]$month
+    this_year <- all_yearmons[month_index]$year
+
+    these_fnames <- copy(dynamic_cov_dt)
+    these_fnames[, year_to_use:=pmin(end_year, this_year)] # cap year by covariate availability
+    these_fnames[, year_to_use:=pmax(year_to_use, start_year)]
+
+    # cap to make sure the specific month_year is available
+    these_fnames[end_year==year_to_use & end_month<this_month, year_to_use:=end_year-1]
+    these_fnames[start_year==year_to_use & start_month>this_month, year_to_use:=start_year+1]
+
+    these_fnames[, new_fname:=str_replace(fname, "YEAR", as.character(year_to_use))]
+    these_fnames[, new_fname:=str_replace(new_fname, "MONTH", str_pad(this_month, 2, pad="0"))]
+    these_fnames[, full_fname:=file.path(vm_path, new_fname)]
+
+    subset <- extract_values(these_fnames$full_fname, raster_indices, reference_raster, names=these_fnames$cov_name)
+    subset[, year:=this_year]
+    subset[, month:=this_month]
+    setcolorder(subset, c("year", "month", "cellnumber", these_fnames$cov_name))
+
+    return(subset)
+  }
+  all_dynamic <- rbindlist(all_dynamic)
+
+  # save dynamic covariates(by year)
+  print("saving dynamic covariates by year")
+  for (this_year in prediction_years){
+    print(this_year)
+    write.csv(all_dynamic[year==this_year], file.path(dynamic_outdir, paste0("dynamic_", this_year,".csv")), row.names=F)
+  }
+  rm(all_dynamic); gc()
+  print("dynamic covariates successfully extracted")
 }
 
-all_annual <- rbindlist(all_annual)
+main <- function() {
+  package_load(c("zoo","raster", "doParallel", "data.table", "rgdal", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm"))
 
-landcov_names <- names(all_annual)[names(all_annual) %like% "Landcover"]
-for (this_name in landcov_names){
-  all_annual[[this_name]] <- all_annual[[this_name]]/100
+  if(Sys.getenv("input_dir")=="") {
+    input_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/input_data/"
+    main_indir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20190614_rearrange_scripts/"
+    main_outdir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20190614_rearrange_scripts/"
+  } else {
+    input_dir <- Sys.getenv("input_dir")
+    main_indir <- Sys.getenv("main_indir")
+    main_outdir <- Sys.getenv("main_outdir")
+  }
+
+  prediction_years <- 2000:2021
+  extract_covariates(input_dir, main_indir, main_outdir, prediction_years)
 }
 
-write.csv(all_annual, file.path(main_outdir, "annual_covariates.csv"), row.names = F)
+# DON'T USE THIS-- FOR FULL DSUB SEE 000_MAKE_DSUB.R
+# dsub --provider google-v2 --project map-special-0001 --image gcr.io/map-demo-0001/map_geospatial --regions europe-west1 --label "type=itn_cube" --machine-type n1-ultramem-40 --logging gs://map_users/amelia/itn/itn_cube/logs --input-recursive input_dir=gs://map_users/amelia/itn/itn_cube/input_data main_indir=gs://map_users/amelia/itn/itn_cube/results/covariates/20190729/ cov_dir=gs://mastergrids_5km --input run_individually=gs://map_users/amelia/itn/code/generate_cube/run_individually.txt CODE=gs://map_users/amelia/itn/code/generate_cube/03_prep_covariates.r --output-recursive main_outdir=gs://map_users/amelia/itn/itn_cube/results/covariates/20190729/ --command 'Rscript ${CODE}'
 
-rm(all_annual); gc()
-print("annual covariates successfully extracted")
-
-### Fully dynamic covariates: extract and apply by month and year  ----------------------------------------------------------------------------#######################  
-
-print("Extracting dynamic covariates")
-
-dynamic_cov_dt <- cov_dt[type=="yearmon"]
-all_yearmons <- data.table(expand.grid(1:12, prediction_years))
-names(all_yearmons) <- c("month", "year")
-
-registerDoParallel(ncores-2)
-
-dynamic_outdir <- file.path(main_outdir, "dynamic_covariates")
-if (!dir.exists(dynamic_outdir)){
-  dir.create(dynamic_outdir)
-}
-
-all_dynamic <- foreach(month_index=1:nrow(all_yearmons)) %dopar% {
-  
-  print(all_yearmons[month_index])
-  
-  this_month <- all_yearmons[month_index]$month
-  this_year <- all_yearmons[month_index]$year
-  
-  these_fnames <- copy(dynamic_cov_dt)
-  these_fnames[, year_to_use:=pmin(end_year, this_year)] # cap year by covariate availability
-  these_fnames[, year_to_use:=pmax(year_to_use, start_year)] 
-  
-  # cap to make sure the specific month_year is available
-  these_fnames[end_year==year_to_use & end_month<this_month, year_to_use:=end_year-1]
-  these_fnames[start_year==year_to_use & start_month>this_month, year_to_use:=start_year+1]
-  
-  these_fnames[, new_fname:=str_replace(fname, "YEAR", as.character(year_to_use))]
-  these_fnames[, new_fname:=str_replace(new_fname, "MONTH", str_pad(this_month, 2, pad="0"))]
-  these_fnames[, full_fname:=file.path(vm_path, new_fname)]
-  
-  subset <- extract_values(these_fnames$full_fname, raster_indices, reference_raster, names=these_fnames$cov_name)
-  subset[, year:=this_year]
-  subset[, month:=this_month]
-  setcolorder(subset, c("year", "month", "cellnumber", these_fnames$cov_name))
-  
-  return(subset)
-}
-all_dynamic <- rbindlist(all_dynamic)
-
-# save dynamic covariates(by year)
-print("saving dynamic covariates by year")
-for (this_year in prediction_years){
-  print(this_year)
-  write.csv(all_dynamic[year==this_year], file.path(dynamic_outdir, paste0("dynamic_", this_year,".csv")), row.names=F)
-}
-rm(all_dynamic); gc()
-print("dynamic covariates successfully extracted")
-
+main()

--- a/itn_cube/00_generate_cube_master.r
+++ b/itn_cube/00_generate_cube_master.r
@@ -7,11 +7,11 @@
 ## output, run 04_batch_submit_predictions.r from your local machine.
 ##############################################################################################################
 
-rm(list=ls())
-big_tic <- Sys.time()
+time_passed <- function(tic, toc){
+  elapsed <- toc-tic
+  print(paste("--> Time Elapsed: ", elapsed, units(elapsed)))
+}
 
-print("Setting up directories for full ITN cube run")
-# todo: set up an image that just has these installed already
 package_load <- function(package_list){
   # package installation/loading
   new_packages <- package_list[!(package_list %in% installed.packages()[,"Package"])]
@@ -19,72 +19,101 @@ package_load <- function(package_list){
   lapply(package_list, library, character.only=T)
 }
 
-time_passed <- function(tic, toc){
-  elapsed <- toc-tic
-  print(paste("--> Time Elapsed: ", elapsed, units(elapsed)))
+generate_cube_master <- function(
+  input_dir,
+  cov_dir,
+  func_dir,
+  main_dir,
+  survey_indir,
+  indicators_indir,
+  start_year,
+  end_year,
+  save_uncertainty,
+  nsamp
+) {
+  ## Prep Data ## ------------------------------------------------------------
+  print("STEP 1: Preparing input data")
+  step_1_tic <- Sys.time()
+  source(file.path(func_dir, "01_prep_data.r"))
+  prep_data(main_indir=input_dir, survey_indir=survey_indir, indicators_indir=indicators_indir, main_outdir=main_dir, func_dir=func_dir)
+  step_1_toc <- Sys.time()
+  time_passed(step_1_tic, step_1_toc)
+
+  ## Prep Covariates ## ------------------------------------------------------------
+  print("STEP 2: Preparing covariates")
+  step_2_tic <- Sys.time()
+  source(file.path(func_dir, "02_prep_covariates.r"))
+  prep_covariates(cov_dir,  main_indir=main_dir, main_outdir=main_dir)
+  step_2_toc <- Sys.time()
+  time_passed(step_2_tic, step_2_toc)
+
+
+  ## Run Regressions ## ------------------------------------------------------------
+  print("STEP 3: Running regressions")
+  step_3_tic <- Sys.time()
+  source(file.path(func_dir, "03_regress.r"))
+  run_dev_gap_models(input_dir, func_dir, main_indir=main_dir, main_outdir=main_dir, start_year, end_year+1, save_uncertainty=save_uncertainty, nsamp=nsamp)
+  step_3_toc <- Sys.time()
+  time_passed(step_3_tic, step_3_toc)
+
+
+  # ## Predict Outputs: For this step you must run 04_batch_submit_predictions from your local machine. ## ------------------------------------------------------------
+
+
+  ## Show time elapsed ## ------------------------------------------------------------
+  print("Stepwise times:")
+  print("Step 1: Input Data Prep")
+  time_passed(step_1_tic, step_1_toc)
+  print("Step 2: Preparing Covariates")
+  time_passed(step_2_tic, step_2_toc)
+  print("Step 3: Running Regressions")
+  time_passed(step_3_tic, step_3_toc)
+
+  print("Full Time:")
+  big_toc <- Sys.time()
+  time_passed(big_tic, big_toc)
 }
 
-package_load(c("zoo","raster","VGAM", "doParallel", "data.table", "lubridate", "ggplot2",
-               "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "pryr", "survey", "RVenn"))
+main <- function() {
+  big_tic <- Sys.time()
+
+  print("Setting up directories for full ITN cube run")
+  # todo: set up an image that just has these installed already
+
+  package_load(c("zoo","raster","VGAM", "doParallel", "data.table", "lubridate", "ggplot2",
+                 "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "pryr", "survey", "RVenn"))
+
+  ##  Environment Prep  ------------------------------------------------------------
+  input_dir <- Sys.getenv("input_dir")
+  cov_dir <- Sys.getenv("cov_dir")
+  func_dir <- Sys.getenv("func_dir")
+  main_dir <- Sys.getenv("main_dir")
+
+  survey_indir <- Sys.getenv("survey_indir")
+  indicators_indir <- Sys.getenv("indicators_indir")
+
+  start_year <- 2000
+  end_year <- 2020
+
+  save_uncertainty <- T # set to TRUE when you want the ability to pull posterior samples from INLA
+  nsamp <- 500
+
+  generate_cube_master(
+    input_dir,
+    cov_dir,
+    func_dir,
+    main_dir,
+    survey_indir,
+    indicators_indir,
+    start_year,
+    end_year,
+    save_uncertainty,
+    nsamp
+  )
+}
 
 # current dsub:
 # dsub --provider google-v2 --project map-special-0001 --image eu.gcr.io/map-special-0001/map-itn-spatial:1.1.0 --preemptible --retries 1 --wait --regions europe-west1 --label "type=itn_cube" --machine-type n1-highmem-64 --disk-size 400 --boot-disk-size 50 --logging gs://map_users/amelia/itn/itn_cube/logs --input-recursive input_dir=gs://map_users/amelia/itn/itn_cube/input_data cov_dir=gs://map_users/amelia/itn/itn_cube/results/covariates/20200401 indicators_indir=gs://map_users/amelia/itn/stock_and_flow/results/20200930_new_2020_dists/for_cube survey_indir=gs://map_users/amelia/itn/stock_and_flow/input_data/01_input_data_prep/20200731 func_dir=gs://map_users/amelia/itn/code/itn_cube/ --input CODE=gs://map_users/amelia/itn/code/itn_cube/00_generate_cube_master.r --output-recursive main_dir=gs://map_users/amelia/itn/itn_cube/results/20201001_new_2020_dists --command 'Rscript ${CODE}'
 
-##  Environment Prep  ------------------------------------------------------------
-input_dir <- Sys.getenv("input_dir")
-cov_dir <- Sys.getenv("cov_dir")
-func_dir <- Sys.getenv("func_dir")
-main_dir <- Sys.getenv("main_dir")
-
-survey_indir <- Sys.getenv("survey_indir")
-indicators_indir <- Sys.getenv("indicators_indir")
-
-start_year <- 2000
-end_year <- 2020
-
-save_uncertainty <- T # set to TRUE when you want the ability to pull posterior samples from INLA
-nsamp <- 500
-
-## Prep Data ## ------------------------------------------------------------
-print("STEP 1: Preparing input data")
-step_1_tic <- Sys.time()
-source(file.path(func_dir, "01_prep_data.r"))
-prep_data(main_indir=input_dir, survey_indir=survey_indir, indicators_indir=indicators_indir, main_outdir=main_dir, func_dir=func_dir)
-step_1_toc <- Sys.time()
-time_passed(step_1_tic, step_1_toc)
-
-## Prep Covariates ## ------------------------------------------------------------
-print("STEP 2: Preparing covariates")
-step_2_tic <- Sys.time()
-source(file.path(func_dir, "02_prep_covariates.r"))
-prep_covariates(cov_dir,  main_indir=main_dir, main_outdir=main_dir)
-step_2_toc <- Sys.time()
-time_passed(step_2_tic, step_2_toc)
-
-
-## Run Regressions ## ------------------------------------------------------------
-print("STEP 3: Running regressions")
-step_3_tic <- Sys.time()
-source(file.path(func_dir, "03_regress.r"))
-run_dev_gap_models(input_dir, func_dir, main_indir=main_dir, main_outdir=main_dir, start_year, end_year+1, save_uncertainty=save_uncertainty, nsamp=nsamp)
-step_3_toc <- Sys.time()
-time_passed(step_3_tic, step_3_toc)
-
-
-# ## Predict Outputs: For this step you must run 04_batch_submit_predictions from your local machine. ## ------------------------------------------------------------
-
-
-## Show time elapsed ## ------------------------------------------------------------
-print("Stepwise times:")
-print("Step 1: Input Data Prep")
-time_passed(step_1_tic, step_1_toc)
-print("Step 2: Preparing Covariates")
-time_passed(step_2_tic, step_2_toc)
-print("Step 3: Running Regressions")
-time_passed(step_3_tic, step_3_toc)
-
-print("Full Time:")
-big_toc <- Sys.time()
-time_passed(big_tic, big_toc)
-
-
+rm(list=ls())
+main()

--- a/itn_cube/00_generate_cube_master.r
+++ b/itn_cube/00_generate_cube_master.r
@@ -20,22 +20,41 @@ package_load <- function(package_list){
 }
 
 generate_cube_master <- function(
-  input_dir,
-  cov_dir,
-  func_dir,
-  main_dir,
-  survey_indir,
-  indicators_indir,
   start_year,
   end_year,
   save_uncertainty,
-  nsamp
+  nsamp,
+  func_dir,
+  iso_gaul_map_csv,
+  africa_raster_mask_tif,
+  snf_probs_means_csv,
+  hh_survey_data_csv,
+  static_covariates_csv,
+  annual_covariates_csv,
+  dynamic_covariates_csvs_dir,
+  survey_data_out_csv,
+  survey_summary_out_csv,
+  data_covariates_out_csv,
+  inla_outputs_out_rdata,
+  inla_outputs_for_prediction_out_rdata,
+  inla_posterior_samples_out_rdata,
+  data_for_regression_out_csv
 ) {
+  big_tic <- Sys.time()
+
   ## Prep Data ## ------------------------------------------------------------
   print("STEP 1: Preparing input data")
   step_1_tic <- Sys.time()
   source(file.path(func_dir, "01_prep_data.r"))
-  prep_data(main_indir=input_dir, survey_indir=survey_indir, indicators_indir=indicators_indir, main_outdir=main_dir, func_dir=func_dir)
+  prep_data(
+    iso_gaul_map_csv = iso_gaul_map_csv,
+    africa_raster_mask_tif = africa_raster_mask_tif,
+    stock_and_flow_probs_means_csv = snf_probs_means_csv,
+    itn_hh_survey_data_csv = hh_survey_data_csv,
+    survey_data_out_csv = survey_data_out_csv,
+    survey_summary_out_csv = survey_summary_out_csv,
+    func_dir
+  )
   step_1_toc <- Sys.time()
   time_passed(step_1_tic, step_1_toc)
 
@@ -43,7 +62,13 @@ generate_cube_master <- function(
   print("STEP 2: Preparing covariates")
   step_2_tic <- Sys.time()
   source(file.path(func_dir, "02_prep_covariates.r"))
-  prep_covariates(cov_dir,  main_indir=main_dir, main_outdir=main_dir)
+  prep_covariates(
+    survey_data_csv = survey_data_out_csv,
+    static_covariates_csv = static_covariates_csv,
+    annual_covariates_csv = annual_covariates_csv,
+    dynamic_covariates_csv_dir = dynamic_covariates_csvs_dir,
+    data_covariates_out_csv = data_covariates_out_csv
+  )
   step_2_toc <- Sys.time()
   time_passed(step_2_tic, step_2_toc)
 
@@ -52,7 +77,18 @@ generate_cube_master <- function(
   print("STEP 3: Running regressions")
   step_3_tic <- Sys.time()
   source(file.path(func_dir, "03_regress.r"))
-  run_dev_gap_models(input_dir, func_dir, main_indir=main_dir, main_outdir=main_dir, start_year, end_year+1, save_uncertainty=save_uncertainty, nsamp=nsamp)
+  run_dev_gap_models(
+    data_covariates_csv = data_covariates_out_csv,
+    func_dir = func_dir,
+    inla_out_rdata = inla_outputs_out_rdata,
+    inla_for_prediction_out_rdata = inla_outputs_for_prediction_out_rdata,
+    inla_posterior_samples_out_rdata = inla_posterior_samples_out_rdata,
+    data_for_model_out_csv = data_for_regression_out_csv,
+    start_year=start_year,
+    end_year=end_year,
+    save_uncertainty = save_uncertainty,
+    nsamp = nsamp
+  )
   step_3_toc <- Sys.time()
   time_passed(step_3_tic, step_3_toc)
 
@@ -75,13 +111,8 @@ generate_cube_master <- function(
 }
 
 main <- function() {
-  big_tic <- Sys.time()
-
   print("Setting up directories for full ITN cube run")
   # todo: set up an image that just has these installed already
-
-  package_load(c("zoo","raster","VGAM", "doParallel", "data.table", "lubridate", "ggplot2",
-                 "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "pryr", "survey", "RVenn"))
 
   ##  Environment Prep  ------------------------------------------------------------
   input_dir <- Sys.getenv("input_dir")
@@ -92,28 +123,64 @@ main <- function() {
   survey_indir <- Sys.getenv("survey_indir")
   indicators_indir <- Sys.getenv("indicators_indir")
 
-  start_year <- 2000
-  end_year <- 2020
+  parser <- arg_parser("Master script for generating ITN regression outputs, in sequence")
+  parser <- add_argument(parser, "--start_year", help="Start year", default=2000)
+  parser <- add_argument(parser, "--end_year", help="End year", default=2021)
+  parser <- add_argument(parser, "--save_uncertainty", help="Set to TRUE when you want the ability to pull posterior samples from INLA", default=TRUE)
+  parser <- add_argument(parser, "--nsamp", help="Number of samples for regression", default=500)
+  parser <- add_argument(parser, "--code_dir", help="Directory containing model code", default=func_dir)
+  parser <- add_argument(parser, "--iso_gaul_map", help="Input CSV file. ISO-to-GAUL names. Default path can be adjusted with env 'input_dir'", default=file.path(input_dir, "general", "iso_gaul_map.csv"))
+  parser <- add_argument(parser, "--africa_raster_mask", help="Input TIF file. Raster mask file, masking non-african area with value -9999. Default path can be adjusted with env 'input_dir'", default=file.path(input_dir, 'general', 'african_cn5km_2013_no_disputes.tif'))
+  parser <- add_argument(parser, "--snf_probs_means", help="Input CSV file. Mean access metrics for cube. Output from S&F step 5. Default path can be adjusted with env 'indicators_indir'", default=file.path(indicators_indir, "stock_and_flow_probs_means.csv"))
+  parser <- add_argument(parser, "--hh_survey_data", help="Input CSV file. Household-level data file. Output from S&F step 1a. Default path can be adjusted with env 'survey_indir'", default=file.path(survey_indir, "itn_hh_survey_data.csv"))
+  parser <- add_argument(parser, "--static_covariates", help="Input CSV file. File containing cleaned extracted static covariates. Default path can be adjusted with env 'cov_dir'", default=file.path(cov_dir, 'static_covariates.csv'))
+  parser <- add_argument(parser, "--annual_covariates", help="Input CSV file. File containing cleaned extracted annual covariates. Default path can be adjusted with env 'cov_dir'", default=file.path(cov_dir, 'annual_covariates.csv'))
+  parser <- add_argument(parser, "--dynamic_covariates", help="Input CSV files directory. Directory containing cleaned extracted dynamic covariates. Default path can be adjusted with env 'cov_dir'", default=file.path(cov_dir, 'dynamic_covariates'))
 
-  save_uncertainty <- T # set to TRUE when you want the ability to pull posterior samples from INLA
-  nsamp <- 500
+  parser <- add_argument(parser, "--survey_data", help="Output CSV file. Prepped household-level data for regression. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "01_survey_data.csv"))
+  parser <- add_argument(parser, "--survey_summary", help="Output CSV file. Summary stats of all surveys. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "01_survey_summary.csv"))
+  parser <- add_argument(parser, "--data_covariates", help="Output CSV file. Prepped household-level data with covariates appended for regression. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "02_data_covariates.csv"))
+  parser <- add_argument(parser, "--inla_outputs", help="Output Rdata file. Large .RData file containing the regression objects for all three model runs. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "03_inla_outputs.Rdata"))
+  parser <- add_argument(parser, "--inla_outputs_for_prediction", help="Output Rdata file. Small .RData file to use when you want to predict only mean outcomes. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "03_inla_outputs_for_prediction.Rdata"))
+  parser <- add_argument(parser, "--inla_posterior_samples", help="Output Rdata file. Medium .RData file that saves posterior samples for prediction in step 04. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "03_inla_posterior_samples.Rdata"))
+  parser <- add_argument(parser, "--data_for_regression", help="Output CSV file. Final dataset that goes into regression. Default path can be adjusted with env 'main_dir'", default=file.path(main_dir, "03_data_for_model.csv"))
+
+  args <- parse_args(parser)
 
   generate_cube_master(
-    input_dir,
-    cov_dir,
-    func_dir,
-    main_dir,
-    survey_indir,
-    indicators_indir,
-    start_year,
-    end_year,
-    save_uncertainty,
-    nsamp
+    args$start_year,
+    args$end_year,
+    args$save_uncertainty,
+    args$nsamp,
+    args$code_dir,
+    args$iso_gaul_map,
+    args$africa_raster_mask,
+    args$snf_probs_means,
+    args$hh_survey_data,
+    args$static_covariates,
+    args$annual_covariates,
+    args$dynamic_covariates,
+    args$survey_data,
+    args$survey_summary,
+    args$data_covariates,
+    args$inla_outputs,
+    args$inla_outputs_for_prediction,
+    args$inla_posterior_samples,
+    args$data_for_regression
   )
 }
 
 # current dsub:
 # dsub --provider google-v2 --project map-special-0001 --image eu.gcr.io/map-special-0001/map-itn-spatial:1.1.0 --preemptible --retries 1 --wait --regions europe-west1 --label "type=itn_cube" --machine-type n1-highmem-64 --disk-size 400 --boot-disk-size 50 --logging gs://map_users/amelia/itn/itn_cube/logs --input-recursive input_dir=gs://map_users/amelia/itn/itn_cube/input_data cov_dir=gs://map_users/amelia/itn/itn_cube/results/covariates/20200401 indicators_indir=gs://map_users/amelia/itn/stock_and_flow/results/20200930_new_2020_dists/for_cube survey_indir=gs://map_users/amelia/itn/stock_and_flow/input_data/01_input_data_prep/20200731 func_dir=gs://map_users/amelia/itn/code/itn_cube/ --input CODE=gs://map_users/amelia/itn/code/itn_cube/00_generate_cube_master.r --output-recursive main_dir=gs://map_users/amelia/itn/itn_cube/results/20201001_new_2020_dists --command 'Rscript ${CODE}'
 
-rm(list=ls())
-main()
+# rm(list=ls())
+package_load(c("zoo","raster","VGAM", "doParallel", "data.table", "lubridate", "ggplot2",
+               "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "pryr", "survey", "RVenn", "argparser", "tryCatchLog", "futile.logger"))
+
+options(keep.source = TRUE)
+options(keep.source.pkgs = TRUE)
+options(tryCatchLog.include.compact.call.stack = FALSE)
+flog.threshold(ERROR)
+tryCatchLog({
+  main()
+})

--- a/itn_cube/02_prep_covariates.r
+++ b/itn_cube/02_prep_covariates.r
@@ -11,16 +11,22 @@
 ## 
 ##############################################################################################################
 
-prep_covariates <- function(cov_dir, main_indir, main_outdir){
+prep_covariates <- function(
+  survey_data_csv,
+  static_covariates_csv,
+  annual_covariates_csv,
+  dynamic_covariates_csv_dir,
+  data_covariates_out_csv
+){
   
   # Load data from create_database.r,  ------------------------------------------------------------
-  data<-fread(file.path(main_indir, "01_survey_data.csv"))
+  data<-fread(survey_data_csv)
   data[, row_id:=as.integer(row.names(data))]
 
   ### Static covariates  ----------------------------------------------------------------------------#######################  
   
   print("Extracting static covariates")
-  all_static <- fread(file.path(cov_dir, "static_covariates.csv"))
+  all_static <- fread(static_covariates_csv)
   data <- merge(data, all_static, by="cellnumber", all.x=T)
   rm(all_static); gc()
   print("static covariates successfully extracted")
@@ -28,7 +34,7 @@ prep_covariates <- function(cov_dir, main_indir, main_outdir){
   ### Annual covariates  ----------------------------------------------------------------------------#######################  
   
   print("Extracting annual covariates")
-  all_annual <- fread(file.path(cov_dir, "annual_covariates.csv"))
+  all_annual <- fread(annual_covariates_csv)
   data <- merge(data, all_annual, by=c("year", "cellnumber"), all.x=T)
   rm(all_annual); gc()
   print("annual covariates successfully extracted")
@@ -37,7 +43,7 @@ prep_covariates <- function(cov_dir, main_indir, main_outdir){
   
   print("Extracting dynamic covariates")
 
-  dynamic_dir <- file.path(cov_dir, "dynamic_covariates")
+  dynamic_dir <- dynamic_covariates_csv_dir
   all_dynamic <- lapply(list.files(dynamic_dir, full.names = T), fread)
   all_dynamic <- rbindlist(all_dynamic)
   
@@ -49,7 +55,7 @@ prep_covariates <- function(cov_dir, main_indir, main_outdir){
   print("dynamic covariates successfully extracted")
   
   print("saving to file")
-  write.csv(data, file.path(main_outdir, "02_data_covariates.csv"), row.names = F)
+  write.csv(data, data_covariates_out_csv, row.names = F)
 }
 
 ## TO RUN THIS SCRIPT INDIVIDUALLY, READ HERE
@@ -81,10 +87,11 @@ if (Sys.getenv("run_individually")!=""){
     cov_dir <- Sys.getenv("cov_dir")
   }
   
-  prep_covariates(cov_dir, main_indir, main_outdir)
-  
+  prep_covariates(
+    survey_data_csv = file.path(main_indir, "01_survey_data.csv"),
+    static_covariates_csv = file.path(cov_dir, "static_covariates.csv"),
+    annual_covariates_csv = file.path(cov_dir, "annual_covariates.csv"),
+    dynamic_covariates_csv_dir = file.path(cov_dir, "dynamic_covariates"),
+    data_covariates_out_csv = file.path(main_outdir, "02_data_covariates.csv")
+  )
 }
-
-
-
-

--- a/itn_cube/03_regress.r
+++ b/itn_cube/03_regress.r
@@ -9,18 +9,29 @@
 ## 
 ##############################################################################################################
 
-run_dev_gap_models <- function(input_dir, func_dir, main_indir, main_outdir, start_year, end_year, save_uncertainty=F, nsamp=100){
+run_dev_gap_models <- function(
+  data_covariates_csv,
+  func_dir,
+  inla_out_rdata,
+  inla_for_prediction_out_rdata,
+  inla_posterior_samples_out_rdata,
+  data_for_model_out_csv,
+  start_year,
+  end_year,
+  save_uncertainty=F,
+  nsamp=100
+){
   
   # set.seed(212)
   
   # load relevant functions
   source(file.path(func_dir, "03_inla_functions.r"))
-  output_fname <- file.path(main_outdir, "03_inla_outputs.Rdata")
-  summary_output_fname <- file.path(main_outdir, "03_inla_outputs_for_prediction.Rdata")
-  posterior_output_fname <- file.path(main_outdir, "03_inla_posterior_samples.Rdata")
+  output_fname <- inla_out_rdata
+  summary_output_fname <- inla_for_prediction_out_rdata
+  posterior_output_fname <- inla_posterior_samples_out_rdata
   
   ## Load data 
-  data <- fread(file.path(main_indir, "02_data_covariates.csv"))
+  data <- fread(data_covariates_csv)
   data <- data[order(row_id)]
   
   ## Check for collinearity ## ---------------------------------------------------------
@@ -155,7 +166,7 @@ run_dev_gap_models <- function(input_dir, func_dir, main_indir, main_outdir, sta
   # limit data to chosen "end year"
   data[, capped_time:=pmin(time, end_year-0.046)]
   
-  write.csv(data, file.path(main_outdir, "03_data_for_model.csv"), row.names=F)
+  write.csv(data, data_for_model_out_csv, row.names=F)
   ## Run model ##------------------------------------------------------------
 
   ncores <- detectCores()
@@ -270,13 +281,11 @@ if (Sys.getenv("run_individually")!=""){
   
   package_load(c("zoo","raster", "doParallel", "data.table", "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "rgeos"))
   
-  if(Sys.getenv("input_dir")=="") {
-    input_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/input_data"
+  if(Sys.getenv("main_indir")=="") {
     main_indir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20200418_BMGF_ITN_C1.00_R1.00_V2/"
     main_outdir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20200418_BMGF_ITN_C1.00_R1.00_V2/"
     func_dir <- "/Users/bertozzivill/repos/map-itn-cube/itn_cube/"
   } else {
-    input_dir <- Sys.getenv("input_dir")
     main_indir <- Sys.getenv("main_indir")
     main_outdir <- Sys.getenv("main_outdir")
     func_dir <- Sys.getenv("func_dir") # code directory for function scripts
@@ -285,8 +294,16 @@ if (Sys.getenv("run_individually")!=""){
   start_year=2000
   end_year=2021
   
-  run_dev_gap_models(input_dir, func_dir, main_indir, main_outdir, start_year=start_year, end_year=end)
-  
+  run_dev_gap_models(
+    data_covariates_csv = file.path(main_indir, "02_data_covariates.csv"),
+    func_dir,
+    inla_out_data = file.path(main_outdir, "03_inla_outputs.Rdata"),
+    inla_for_prediction_out_rdata = file.path(main_outdir, "03_inla_outputs_for_prediction.Rdata"),
+    inla_posterior_samples_out_rdata = file.path(main_outdir, "03_inla_posterior_samples.Rdata"),
+    data_for_model_out_csv = file.path(main_outdir, "03_data_for_model.csv"),
+    start_year=start_year,
+    end_year=end
+  )
 }
 
 

--- a/itn_cube/04_batch_submit_predictions.r
+++ b/itn_cube/04_batch_submit_predictions.r
@@ -86,7 +86,7 @@ for (idx in 1:nrow(to_submit)){
                      paste0("CODE=", cloud_func_dir, "04_predict_rasters.r")
   )
   
-  final_str <- paste0("--command 'Rscript ${CODE} ",  this_year, "' ")
+  final_str <- paste0("--command 'Rscript ${CODE} --year ",  this_year, "' ")
   
   full_dsub_str <- paste(dsub_str, label_str, machine_str, disk_str, boot_disk_str, preempt_str,
                          logging_str, input_str, input_dir_str, output_dir_str, final_str)

--- a/itn_cube/04_predict_rasters.r
+++ b/itn_cube/04_predict_rasters.r
@@ -8,7 +8,6 @@
 ## uncertainty, relative uncertainty, and exceedance. 
 ##############################################################################################################
 
-print("Loading Packages")
 package_load <- function(package_list){
   # package installation/loading
   new_packages <- package_list[!(package_list %in% installed.packages()[,"Package"])]
@@ -18,312 +17,334 @@ package_load <- function(package_list){
   lapply(package_list, library, character.only=T)
 }
 
-package_load(c("zoo", "VGAM", "raster", "doParallel", "data.table", "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "pryr",
-               "matrixStats", "Matrix.utils"))
-
-## Input info ----------------------------------------------------------------------------------------
-
-if(Sys.getenv("input_dir")=="") {
-  this_year <- 2012
-  input_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/input_data"
-  main_indir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20200501_BMGF_ITN_C1.00_R1.00_V2_with_uncertainty/"
-  indicators_indir <- "/Volumes/GoogleDrive/My Drive/stock_and_flow/results/20200418_BMGF_ITN_C1.00_R1.00_V2/for_cube"
-  main_outdir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20200501_BMGF_ITN_C1.00_R1.00_V2_with_uncertainty/"
-  static_cov_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/covariates/20200401/static_covariates.csv"
-  annual_cov_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/covariates/20200401/annual_covariates.csv"
-  dynamic_cov_dir <- paste0("/Volumes/GoogleDrive/My Drive/itn_cube/results/covariates/20200401/dynamic_covariates/dynamic_", this_year, ".csv")
-  func_dir <- "/Users/bertozzivill/repos/map-itn-cube/itn_cube/"
-  testing <- T
-} else {
-  this_year <- commandArgs(trailingOnly=TRUE)[1]
-  input_dir <- Sys.getenv("input_dir")
-  main_indir <- Sys.getenv("main_indir")
-  indicators_indir <- Sys.getenv("indicators_indir")
-  main_outdir <- Sys.getenv("main_outdir")
-  static_cov_dir <- Sys.getenv("static_cov_dir")
-  annual_cov_dir <- Sys.getenv("annual_cov_dir")
-  dynamic_cov_dir <- Sys.getenv("dynamic_cov_dir")
-  func_dir <- Sys.getenv("func_dir") # code directory for function scripts
-  testing <- F
-}
-
 time_passed <- function(tic, toc){
   elapsed <- toc-tic
   print(paste("--> Time Elapsed: ", elapsed, units(elapsed)))
 }
 
-print("Predicting")
-prediction_type <- "uncertainty"
-nsamp <- 200
+predict_rasters <- function(
+  this_year,
+  input_dir,
+  main_indir,
+  indicators_indir,
+  main_outdir,
+  static_cov_dir,
+  annual_cov_dir,
+  dynamic_cov_dir,
+  func_dir,
+  testing
+) {
+  print("Predicting")
+  prediction_type <- "uncertainty"
+  nsamp <- 200
 
-start_time <- Sys.time()
-print(paste("Start time:", start_time))
+  start_time <- Sys.time()
+  print(paste("Start time:", start_time))
 
+  ## Setup  ----------------------------------------------------------------------------------------
 
-## Setup  ----------------------------------------------------------------------------------------
+  this_year <- as.integer(this_year)
+  print(paste("predicting for year", this_year))
+  print(mem_used())
 
-this_year <- as.integer(this_year)
-print(paste("predicting for year", this_year))
-print(mem_used())
+  # output directory creation
+  out_dir <- file.path(main_outdir, "04_predictions")
+  dir.create(out_dir, recursive=T,showWarnings = F)
+  dir.create(file.path(out_dir, "aggregated"), showWarnings = F)
+  dir.create(file.path(out_dir, "rasters"), showWarnings = F)
+  dir.create(file.path(out_dir, "raster_draws"), showWarnings=F)
 
-# output directory creation
-out_dir <- file.path(main_outdir, "04_predictions")
-dir.create(out_dir, recursive=T,showWarnings = F)
-dir.create(file.path(out_dir, "aggregated"), showWarnings = F)
-dir.create(file.path(out_dir, "rasters"), showWarnings = F)
-dir.create(file.path(out_dir, "raster_draws"), showWarnings=F)
+  # load function script
+  source(file.path(func_dir, "03_inla_functions.r")) # for ll_to_xyz and predict_inla
+  source(file.path(func_dir, "04_prediction_functions.r"))
 
-# load function script
-source(file.path(func_dir, "03_inla_functions.r")) # for ll_to_xyz and predict_inla
-source(file.path(func_dir, "04_prediction_functions.r"))
-
-# locations of prediction objects
-if (prediction_type=="uncertainty"){
-  stockflow_fname <- file.path(indicators_indir, "stock_and_flow_by_draw.csv")
-  # stockflow_fname <- file.path(indicators_indir, "stock_and_flow_access_npc.csv")
-  for_prediction_fname <- file.path(main_indir, "03_inla_posterior_samples.Rdata")
-}else if (prediction_type=="mean"){
-  stockflow_fname <- file.path(indicators_indir, "stock_and_flow_access_npc.csv")
-  for_prediction_fname <- file.path(main_indir, "03_inla_outputs_for_prediction.Rdata")
-}else{
-  stop(paste("Unknown prediction type", prediction_type))
-}
-
-
-inla_metric_names <- c("access_dev", "use_gap", "percapita_net_dev")
-
-print("Setup complete.")
-print(mem_used())
-
-## Load input objects  ----------------------------------------------------------------------------------------
-print("Loading input objects")
-
-# stock and flow
-base_stock_and_flow <- fread(stockflow_fname)
-if ("ITER" %in% names(base_stock_and_flow)){ # will be true for results by draw
-  base_stock_and_flow[, ITER:=NULL]
-}else if (prediction_type=="mean"){ # mean results will need a uniform "sample" variable
-  base_stock_and_flow[, sample:=0]
-}
-base_stock_and_flow <- base_stock_and_flow[year==this_year & sample %in% 1:nsamp]
-base_stock_and_flow[, emp_nat_access:=emplogit(nat_access)]
-time_map <- unique(base_stock_and_flow[, list(month, time)])
-
-# inla outputs
-inla_outputs_for_prediction <- get_prediction_objects(for_prediction_fname, inla_metric_names, nsamp)
-if ("fixed" %in% names(inla_outputs_for_prediction[[1]])){
-  all_inla_cov_names <- rownames(inla_outputs_for_prediction[[1]]$fixed)
-}else{
-  all_inla_cov_names <- rownames(inla_outputs_for_prediction[[1]]$samples[[1]]$fixed)
-}
-
-# name map
-iso_gaul_map<-fread(file.path(input_dir, "general/iso_gaul_map.csv"))
-setnames(iso_gaul_map, c("GAUL_CODE", "COUNTRY_ID", "NAME"), c("gaul", "iso3", "country"))
-
-print("Input object loading complete.")
-print(mem_used())
-
-## Load covariates  ----------------------------------------------------------------------------------------
-print("Loading covariates")
-
-print("Dynamic")
-thisyear_covs <- fread(dynamic_cov_dir)
-# find and delete the cellnumbers that contain NA's for any month
-to_keep <- thisyear_covs[, lapply(.SD, sum), by=cellnumber]
-to_keep <- to_keep[complete.cases(to_keep)]$cellnumber
-thisyear_covs <- thisyear_covs[cellnumber %in% to_keep]
-rm(to_keep)
-
-print("Annual")
-thisyear_covs <- merge(thisyear_covs, fread(annual_cov_dir), 
-                       by=c("cellnumber", "year"))
-
-print("Static")
-thisyear_covs <- merge(thisyear_covs, fread(static_cov_dir), by="cellnumber")
-thisyear_covs[, "Intercept":=1]
-
-thisyear_covs <- thisyear_covs[complete.cases(thisyear_covs)]
-prediction_indices <- thisyear_covs[month==1]$cellnumber
-
-print("Covariate loading complete.")
-print(mem_used())
-
-
-## Load and format pixel spatial info  ----------------------------------------------------------------------------------------
-print("Loading and formatting pixel locations")
-national_raster <- raster(file.path(input_dir, "general/african_cn5km_2013_no_disputes.tif"))
-NAvalue(national_raster) <- -9999
-
-prediction_cells <- data.table(row_id=prediction_indices, gaul=extract(national_raster, prediction_indices))
-prediction_cells <- cbind(prediction_cells, data.table(xyFromCell(national_raster, prediction_indices)))
-setnames(prediction_cells, c("x", "y"), c("longitude", "latitude"))
-prediction_cells <- merge(prediction_cells, iso_gaul_map, by="gaul", all.x=T)
-setnames(prediction_cells, "row_id", "cellnumber")
-prediction_cells <- prediction_cells[order(cellnumber)]
-prediction_cells <- prediction_cells[iso3 %in% base_stock_and_flow$iso3]
-
-prediction_indices <- prediction_cells$cellnumber
-prediction_xyz <- ll_to_xyz(prediction_cells[, list(row_id=cellnumber, longitude, latitude)])
-
-print("Pixel formatting complete.")
-print(mem_used())
-
-## Format and transform covariates  ----------------------------------------------------------------------------------------
-print("Formatting covariates")
-
-thisyear_covs <- thisyear_covs[cellnumber %in% prediction_cells$cellnumber]
-population <- thisyear_covs[month==1, list(cellnumber, pop=Population)]
-thisyear_covs <- split(thisyear_covs, by="month")
-
-if (testing & length(unique(prediction_cells$iso3))>1){
-  thisyear_covs <- thisyear_covs[1:2]
-}
-months_to_predict <- as.integer(names(thisyear_covs))
-
-print("Converting covariates to matrix for prediction")
-# in case months get out of order somehow
-pred_cov_names <- unlist(lapply(thisyear_covs, function(this_df){
-  return(unique(this_df$month))
-}), use.names=F)
-
-thisyear_covs <- lapply(thisyear_covs, function(this_df){
-  return(as.matrix(this_df[, all_inla_cov_names, with=F]))
-})
-
-print("Covariate formatting complete.")
-print(mem_used())
-
-## Format A matrices  ----------------------------------------------------------------------------------------
-print("Generating A-matrix objects")
-# make A_matrix for each output variable
-print("A_matrix")
-for (output_var in names(inla_outputs_for_prediction)){
-  temporal_mesh <- inla_outputs_for_prediction[[output_var]][["temporal_mesh"]]
-  if (is.null(temporal_mesh)){
-    A_matrix <- lapply(months_to_predict, function(this_month){
-      inla.spde.make.A(inla_outputs_for_prediction[[output_var]][["spatial_mesh"]], 
-                       loc=as.matrix(prediction_xyz[, list(x,y,z)]))
-    })
+  # locations of prediction objects
+  if (prediction_type=="uncertainty"){
+    stockflow_fname <- file.path(indicators_indir, "stock_and_flow_by_draw.csv")
+    # stockflow_fname <- file.path(indicators_indir, "stock_and_flow_access_npc.csv")
+    for_prediction_fname <- file.path(main_indir, "03_inla_posterior_samples.Rdata")
+  }else if (prediction_type=="mean"){
+    stockflow_fname <- file.path(indicators_indir, "stock_and_flow_access_npc.csv")
+    for_prediction_fname <- file.path(main_indir, "03_inla_outputs_for_prediction.Rdata")
   }else{
-    A_matrix <- lapply(months_to_predict, function(this_month){
-      inla.spde.make.A(inla_outputs_for_prediction[[output_var]][["spatial_mesh"]], 
-                       loc=as.matrix(prediction_xyz[, list(x,y,z)]), 
-                       group=rep(min(time_map[month==this_month]$time, max(temporal_mesh$interval)), length(prediction_indices)),
-                       group.mesh=temporal_mesh)
-    })
+    stop(paste("Unknown prediction type", prediction_type))
   }
-  inla_outputs_for_prediction[[output_var]][["A_matrix"]] <- A_matrix
+
+
+  inla_metric_names <- c("access_dev", "use_gap", "percapita_net_dev")
+
+  print("Setup complete.")
+  print(mem_used())
+
+  ## Load input objects  ----------------------------------------------------------------------------------------
+  print("Loading input objects")
+
+  # stock and flow
+  base_stock_and_flow <- fread(stockflow_fname)
+  if ("ITER" %in% names(base_stock_and_flow)){ # will be true for results by draw
+    base_stock_and_flow[, ITER:=NULL]
+  }else if (prediction_type=="mean"){ # mean results will need a uniform "sample" variable
+    base_stock_and_flow[, sample:=0]
+  }
+  base_stock_and_flow <- base_stock_and_flow[year==this_year & sample %in% 1:nsamp]
+  base_stock_and_flow[, emp_nat_access:=emplogit(nat_access)]
+  time_map <- unique(base_stock_and_flow[, list(month, time)])
+
+  # inla outputs
+  inla_outputs_for_prediction <- get_prediction_objects(for_prediction_fname, inla_metric_names, nsamp)
+  if ("fixed" %in% names(inla_outputs_for_prediction[[1]])){
+    all_inla_cov_names <- rownames(inla_outputs_for_prediction[[1]]$fixed)
+  }else{
+    all_inla_cov_names <- rownames(inla_outputs_for_prediction[[1]]$samples[[1]]$fixed)
+  }
+
+  # name map
+  iso_gaul_map<-fread(file.path(input_dir, "general/iso_gaul_map.csv"))
+  setnames(iso_gaul_map, c("GAUL_CODE", "COUNTRY_ID", "NAME"), c("gaul", "iso3", "country"))
+
+  print("Input object loading complete.")
+  print(mem_used())
+
+  ## Load covariates  ----------------------------------------------------------------------------------------
+  print("Loading covariates")
+
+  print("Dynamic")
+  thisyear_covs <- fread(dynamic_cov_dir)
+  # find and delete the cellnumbers that contain NA's for any month
+  to_keep <- thisyear_covs[, lapply(.SD, sum), by=cellnumber]
+  to_keep <- to_keep[complete.cases(to_keep)]$cellnumber
+  thisyear_covs <- thisyear_covs[cellnumber %in% to_keep]
+  rm(to_keep)
+
+  print("Annual")
+  thisyear_covs <- merge(thisyear_covs, fread(annual_cov_dir),
+                         by=c("cellnumber", "year"))
+
+  print("Static")
+  thisyear_covs <- merge(thisyear_covs, fread(static_cov_dir), by="cellnumber")
+  thisyear_covs[, "Intercept":=1]
+
+  thisyear_covs <- thisyear_covs[complete.cases(thisyear_covs)]
+  prediction_indices <- thisyear_covs[month==1]$cellnumber
+
+  print("Covariate loading complete.")
+  print(mem_used())
+
+
+  ## Load and format pixel spatial info  ----------------------------------------------------------------------------------------
+  print("Loading and formatting pixel locations")
+  national_raster <- raster(file.path(input_dir, "general/african_cn5km_2013_no_disputes.tif"))
+  NAvalue(national_raster) <- -9999
+
+  prediction_cells <- data.table(row_id=prediction_indices, gaul=extract(national_raster, prediction_indices))
+  prediction_cells <- cbind(prediction_cells, data.table(xyFromCell(national_raster, prediction_indices)))
+  setnames(prediction_cells, c("x", "y"), c("longitude", "latitude"))
+  prediction_cells <- merge(prediction_cells, iso_gaul_map, by="gaul", all.x=T)
+  setnames(prediction_cells, "row_id", "cellnumber")
+  prediction_cells <- prediction_cells[order(cellnumber)]
+  prediction_cells <- prediction_cells[iso3 %in% base_stock_and_flow$iso3]
+
+  prediction_indices <- prediction_cells$cellnumber
+  prediction_xyz <- ll_to_xyz(prediction_cells[, list(row_id=cellnumber, longitude, latitude)])
+
+  print("Pixel formatting complete.")
+  print(mem_used())
+
+  ## Format and transform covariates  ----------------------------------------------------------------------------------------
+  print("Formatting covariates")
+
+  thisyear_covs <- thisyear_covs[cellnumber %in% prediction_cells$cellnumber]
+  population <- thisyear_covs[month==1, list(cellnumber, pop=Population)]
+  thisyear_covs <- split(thisyear_covs, by="month")
+
+  if (testing & length(unique(prediction_cells$iso3))>1){
+    thisyear_covs <- thisyear_covs[1:2]
+  }
+  months_to_predict <- as.integer(names(thisyear_covs))
+
+  print("Converting covariates to matrix for prediction")
+  # in case months get out of order somehow
+  pred_cov_names <- unlist(lapply(thisyear_covs, function(this_df){
+    return(unique(this_df$month))
+  }), use.names=F)
+
+  thisyear_covs <- lapply(thisyear_covs, function(this_df){
+    return(as.matrix(this_df[, all_inla_cov_names, with=F]))
+  })
+
+  print("Covariate formatting complete.")
+  print(mem_used())
+
+  ## Format A matrices  ----------------------------------------------------------------------------------------
+  print("Generating A-matrix objects")
+  # make A_matrix for each output variable
+  print("A_matrix")
+  for (output_var in names(inla_outputs_for_prediction)){
+    temporal_mesh <- inla_outputs_for_prediction[[output_var]][["temporal_mesh"]]
+    if (is.null(temporal_mesh)){
+      A_matrix <- lapply(months_to_predict, function(this_month){
+        inla.spde.make.A(inla_outputs_for_prediction[[output_var]][["spatial_mesh"]],
+                         loc=as.matrix(prediction_xyz[, list(x,y,z)]))
+      })
+    }else{
+      A_matrix <- lapply(months_to_predict, function(this_month){
+        inla.spde.make.A(inla_outputs_for_prediction[[output_var]][["spatial_mesh"]],
+                         loc=as.matrix(prediction_xyz[, list(x,y,z)]),
+                         group=rep(min(time_map[month==this_month]$time, max(temporal_mesh$interval)), length(prediction_indices)),
+                         group.mesh=temporal_mesh)
+      })
+    }
+    inla_outputs_for_prediction[[output_var]][["A_matrix"]] <- A_matrix
+  }
+  rm(A_matrix, temporal_mesh, output_var, prediction_xyz, prediction_indices)
+
+  print("A-matrix objects generated.")
+  print(mem_used())
+
+
+  ## Actual prediction  ----------------------------------------------------------------------------------------
+  print("Predicting")
+
+  full_predictions <- lapply(inla_outputs_for_prediction, function(this_model){
+    print(this_model$output_var)
+    sub_predictions <- lapply(1:length(thisyear_covs), function(month_idx){
+      print(paste("month", month_idx))
+      return(predict_by_model(this_model, thisyear_covs[[month_idx]], month_idx))
+    })
+  })
+
+  print("Predictions complete")
+  print(mem_used())
+
+  rm(thisyear_covs, inla_outputs_for_prediction)
+
+  ## Transforming prediction objects, find national means & cis  ----------------------------------------------------------------------------------------
+
+  print("Transforming predictions")
+
+  # transform stock and flow into a pixel-level estimate
+  access_stockflow <- format_stockflow(base_stock_and_flow, "emp_nat_access", months_to_predict, prediction_cells)
+
+  full_predictions[["access_dev"]] <- Map("+", full_predictions[["access_dev"]], access_stockflow)
+  full_predictions[["use_gap"]] <- Map("-", full_predictions[["access_dev"]], full_predictions[["use_gap"]])
+  names(full_predictions) <- c("access", "use", "percapita_net_dev")
+  percapita_stockflow <- format_stockflow(base_stock_and_flow, "nat_percapita_nets", months_to_predict, prediction_cells)
+  full_predictions[["percapita_nets"]] <- lapply(Map("+", full_predictions[["percapita_net_dev"]], percapita_stockflow), pmax, 0)
+
+  for(idx in 1:length(full_predictions[["percapita_net_dev"]])){colnames(full_predictions[["percapita_net_dev"]][[idx]]) <- 1:nsamp}
+
+  # transform into level space
+  full_predictions[["access"]] <- lapply(full_predictions[["access"]], plogis)
+  full_predictions[["use"]] <- lapply(full_predictions[["use"]], plogis)
+  access_stockflow <- lapply(access_stockflow, plogis)
+
+  print("Predictions transformed.")
+  print(mem_used())
+  sort( sapply(ls(),function(x){object.size(get(x))}))
+
+  print("Calculating national summary stats")
+  # find national-level summary stats for indicators
+  base_df <- cbind(prediction_cells[, list(iso3)], population[, list(pop)])
+  base_df[, cont:="AFR"]
+
+  nat_level <- list(access = aggregate_to_nat(full_predictions[["access"]], base_df=base_df),
+                    access_dev = aggregate_to_nat(Map("-", full_predictions[["access"]], access_stockflow), base_df=base_df),
+                    use = aggregate_to_nat(full_predictions[["use"]], base_df=base_df),
+                    use_gap = aggregate_to_nat(Map("-", full_predictions[["access"]], full_predictions[["use"]]), base_df=base_df),
+                    use_rate = aggregate_to_nat( lapply(Map("/", full_predictions[["use"]], full_predictions[["access"]]), pmin, 1), base_df=base_df),
+                    percapita_nets = aggregate_to_nat(full_predictions[["percapita_nets"]], base_df=base_df),
+                    percapita_net_dev = aggregate_to_nat(full_predictions[["percapita_net_dev"]], base_df=base_df)
+  )
+  for (name in names(nat_level)){ nat_level[[name]][, variable:=name]}
+  nat_level <- rbindlist(nat_level)
+
+  full_predictions[["percapita_net_dev"]] <- NULL
+
+  # format and save nat_level
+  nat_level <- merge(nat_level, time_map, all.x=T)
+  nat_level[, year:=this_year]
+  suffix <- ifelse(prediction_type=="mean", "_mean_ONLY", "")
+  write.csv(nat_level, file.path(out_dir, "aggregated", paste0("aggregated_predictions_", this_year, suffix, ".csv")), row.names=F)
+
+  print("Summary stats calculated.")
+  print(mem_used())
+  rm(access_stockflow, percapita_stockflow, nat_level, base_df, population, base_stock_and_flow)
+
+  ## Aggregate to annual level, save rasters  ----------------------------------------------------------------------------------------
+
+  sort( sapply(ls(),function(x){object.size(get(x))}))
+
+  print("Finding annual means.")
+  annual_predictions <- lapply(full_predictions, mean_of_matrices)
+
+  annual_predictions[["use_gap"]] <- mean_of_matrices(Map("-", full_predictions[["access"]], full_predictions[["use"]]))
+  annual_predictions[["use_rate"]] <- mean_of_matrices(lapply(Map("/", full_predictions[["use"]], full_predictions[["access"]]), pmin, 1))
+  rm(full_predictions)
+
+  exceedence_cutoffs <- seq(0.1, 0.9, 0.1)
+  annual_summary_stats <- lapply(annual_predictions, pixel_summary_stats, exceedence_cutoffs=exceedence_cutoffs)
+
+  print("Annual means calculated.")
+  print(mem_used())
+  rm(annual_predictions)
+
+  print("Making maps.")
+  all_maps <- lapply(names(annual_summary_stats), function(this_var){
+    print(this_var)
+    var_maps <- lapply(colnames(annual_summary_stats[[this_var]]), function(this_col){
+      print(this_col)
+      this_out_fname <- file.path(out_dir, "rasters", paste0("ITN_", this_year, "_", this_var, "_", this_col, ".tif"))
+      make_raster(annual_summary_stats[[this_var]][, this_col], cellnumbers=prediction_cells$cellnumber, raster_template=national_raster, out_fname=this_out_fname)
+    })
+  })
+
+  print(paste("Maps made, process complete for year,", this_year))
+  print(mem_used())
 }
-rm(A_matrix, temporal_mesh, output_var, prediction_xyz, prediction_indices)
 
-print("A-matrix objects generated.")
-print(mem_used())
+main <- function() {
+  print("Loading Packages")
+  package_load(c("zoo", "VGAM", "raster", "doParallel", "data.table", "rgdal", "INLA", "RColorBrewer", "cvTools", "boot", "stringr", "dismo", "gbm", "pryr",
+                 "matrixStats", "Matrix.utils"))
 
+  ## Input info ----------------------------------------------------------------------------------------
 
-## Actual prediction  ----------------------------------------------------------------------------------------
-print("Predicting")
+  if(Sys.getenv("input_dir")=="") {
+    this_year <- 2012
+    input_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/input_data"
+    main_indir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20200501_BMGF_ITN_C1.00_R1.00_V2_with_uncertainty/"
+    indicators_indir <- "/Volumes/GoogleDrive/My Drive/stock_and_flow/results/20200418_BMGF_ITN_C1.00_R1.00_V2/for_cube"
+    main_outdir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/20200501_BMGF_ITN_C1.00_R1.00_V2_with_uncertainty/"
+    static_cov_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/covariates/20200401/static_covariates.csv"
+    annual_cov_dir <- "/Volumes/GoogleDrive/My Drive/itn_cube/results/covariates/20200401/annual_covariates.csv"
+    dynamic_cov_dir <- paste0("/Volumes/GoogleDrive/My Drive/itn_cube/results/covariates/20200401/dynamic_covariates/dynamic_", this_year, ".csv")
+    func_dir <- "/Users/bertozzivill/repos/map-itn-cube/itn_cube/"
+    testing <- T
+  } else {
+    this_year <- commandArgs(trailingOnly=TRUE)[1]
+    input_dir <- Sys.getenv("input_dir")
+    main_indir <- Sys.getenv("main_indir")
+    indicators_indir <- Sys.getenv("indicators_indir")
+    main_outdir <- Sys.getenv("main_outdir")
+    static_cov_dir <- Sys.getenv("static_cov_dir")
+    annual_cov_dir <- Sys.getenv("annual_cov_dir")
+    dynamic_cov_dir <- Sys.getenv("dynamic_cov_dir")
+    func_dir <- Sys.getenv("func_dir") # code directory for function scripts
+    testing <- F
+  }
 
-full_predictions <- lapply(inla_outputs_for_prediction, function(this_model){
-  print(this_model$output_var)
-  sub_predictions <- lapply(1:length(thisyear_covs), function(month_idx){
-    print(paste("month", month_idx))
-    return(predict_by_model(this_model, thisyear_covs[[month_idx]], month_idx))
-  })
-})
+  predict_rasters(
+    this_year,
+    input_dir,
+    main_indir,
+    indicators_indir,
+    main_outdir,
+    static_cov_dir,
+    annual_cov_dir,
+    dynamic_cov_dir,
+    func_dir,
+    testing
+  )
+}
 
-print("Predictions complete")
-print(mem_used())
-
-rm(thisyear_covs, inla_outputs_for_prediction)
-
-## Transforming prediction objects, find national means & cis  ----------------------------------------------------------------------------------------
-
-print("Transforming predictions")
-
-# transform stock and flow into a pixel-level estimate
-access_stockflow <- format_stockflow(base_stock_and_flow, "emp_nat_access", months_to_predict, prediction_cells)
-
-full_predictions[["access_dev"]] <- Map("+", full_predictions[["access_dev"]], access_stockflow)
-full_predictions[["use_gap"]] <- Map("-", full_predictions[["access_dev"]], full_predictions[["use_gap"]])
-names(full_predictions) <- c("access", "use", "percapita_net_dev")
-percapita_stockflow <- format_stockflow(base_stock_and_flow, "nat_percapita_nets", months_to_predict, prediction_cells)
-full_predictions[["percapita_nets"]] <- lapply(Map("+", full_predictions[["percapita_net_dev"]], percapita_stockflow), pmax, 0)
-
-for(idx in 1:length(full_predictions[["percapita_net_dev"]])){colnames(full_predictions[["percapita_net_dev"]][[idx]]) <- 1:nsamp}
-
-# transform into level space
-full_predictions[["access"]] <- lapply(full_predictions[["access"]], plogis)
-full_predictions[["use"]] <- lapply(full_predictions[["use"]], plogis)
-access_stockflow <- lapply(access_stockflow, plogis)
-
-print("Predictions transformed.")
-print(mem_used())
-sort( sapply(ls(),function(x){object.size(get(x))})) 
-
-print("Calculating national summary stats")
-# find national-level summary stats for indicators
-base_df <- cbind(prediction_cells[, list(iso3)], population[, list(pop)])
-base_df[, cont:="AFR"]
-
-nat_level <- list(access = aggregate_to_nat(full_predictions[["access"]], base_df=base_df),
-                  access_dev = aggregate_to_nat(Map("-", full_predictions[["access"]], access_stockflow), base_df=base_df),
-                  use = aggregate_to_nat(full_predictions[["use"]], base_df=base_df),
-                  use_gap = aggregate_to_nat(Map("-", full_predictions[["access"]], full_predictions[["use"]]), base_df=base_df),
-                  use_rate = aggregate_to_nat( lapply(Map("/", full_predictions[["use"]], full_predictions[["access"]]), pmin, 1), base_df=base_df),
-                  percapita_nets = aggregate_to_nat(full_predictions[["percapita_nets"]], base_df=base_df),
-                  percapita_net_dev = aggregate_to_nat(full_predictions[["percapita_net_dev"]], base_df=base_df)
-)
-for (name in names(nat_level)){ nat_level[[name]][, variable:=name]}
-nat_level <- rbindlist(nat_level)
-
-full_predictions[["percapita_net_dev"]] <- NULL
-
-# format and save nat_level
-nat_level <- merge(nat_level, time_map, all.x=T)
-nat_level[, year:=this_year]
-suffix <- ifelse(prediction_type=="mean", "_mean_ONLY", "")
-write.csv(nat_level, file.path(out_dir, "aggregated", paste0("aggregated_predictions_", this_year, suffix, ".csv")), row.names=F)
-
-print("Summary stats calculated.")
-print(mem_used())
-rm(access_stockflow, percapita_stockflow, nat_level, base_df, population, base_stock_and_flow)
-
-## Aggregate to annual level, save rasters  ----------------------------------------------------------------------------------------
-
-sort( sapply(ls(),function(x){object.size(get(x))})) 
-
-print("Finding annual means.")
-annual_predictions <- lapply(full_predictions, mean_of_matrices)
-
-annual_predictions[["use_gap"]] <- mean_of_matrices(Map("-", full_predictions[["access"]], full_predictions[["use"]]))
-annual_predictions[["use_rate"]] <- mean_of_matrices(lapply(Map("/", full_predictions[["use"]], full_predictions[["access"]]), pmin, 1))
-rm(full_predictions)
-
-exceedence_cutoffs <- seq(0.1, 0.9, 0.1)
-annual_summary_stats <- lapply(annual_predictions, pixel_summary_stats, exceedence_cutoffs=exceedence_cutoffs)
-
-print("Annual means calculated.")
-print(mem_used())
-rm(annual_predictions)
-
-print("Making maps.")
-all_maps <- lapply(names(annual_summary_stats), function(this_var){
-  print(this_var)
-  var_maps <- lapply(colnames(annual_summary_stats[[this_var]]), function(this_col){
-    print(this_col)
-    this_out_fname <- file.path(out_dir, "rasters", paste0("ITN_", this_year, "_", this_var, "_", this_col, ".tif"))
-    make_raster(annual_summary_stats[[this_var]][, this_col], cellnumbers=prediction_cells$cellnumber, raster_template=national_raster, out_fname=this_out_fname)
-  })
-})
-
-print(paste("Maps made, process complete for year,", this_year))
-print(mem_used())
-
-
-
-
-
-
-
-
+main()


### PR DESCRIPTION
This is pretty much the same this as #217 but for the ITN cube part.

Running the scripts should be backwards compatible except for `04_predict_rasters.r`, where the year parameter is a named argument instead of a positional one.

Another addition in each script is this code:

```
options(keep.source = TRUE)
options(keep.source.pkgs = TRUE)
options(tryCatchLog.include.compact.call.stack = FALSE)
flog.threshold(ERROR)
tryCatchLog({
  main()
})
```

It uses the [tryCatchLog ](https://github.com/aryoda/tryCatchLog) package for a slightly improved trace when an error is thrown. Occasionally line numbers are included (not clear to me exactly when). It's a real pain when a long running script errors somewhere and R doesn't give much information as to where, this should help a bit with finding out where.

If you want to look at the diff in a more manageable fashion I would suggest skipping the commits that start with "move" (code is purely moved around/put into functions there) and just look at the ones that start with "add".